### PR TITLE
[Chore] upgrade Meshery adapter library to v0.1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 
 require (
-	github.com/layer5io/meshery-adapter-library v0.1.23
+	github.com/layer5io/meshery-adapter-library v0.1.24
 	github.com/layer5io/meshkit v0.2.28
 	github.com/layer5io/service-mesh-performance v0.3.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334/go.mod h1:UmrVd7x+bNVKrpmKgTtfRiTKHZeNPcMjQproJ0vGwhE=
 github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20210317075357-06b4f88b3e34 h1:QaViadDOBCMDUwYx78kfRvHMkzRVnh/GOhm3s2gxoP4=
 github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20210317075357-06b4f88b3e34/go.mod h1:BQPLwdJt7v7y0fXIejI4whR9zMyX07Wjt5xrbgEmHLw=
-github.com/layer5io/meshery-adapter-library v0.1.23 h1:7eGxHJL4Ag6gU2ZBqsYrbBkQBJFv7Tcob8SZ3wgwrNI=
-github.com/layer5io/meshery-adapter-library v0.1.23/go.mod h1:SLknhKksSoUtKzG2tvJKkN/DsMnGV+O+etmuj5Qew48=
+github.com/layer5io/meshery-adapter-library v0.1.24 h1:3U5oIZCyfPCqVeorTUqZnOhnwcdA/gUHtsDVShhpzaU=
+github.com/layer5io/meshery-adapter-library v0.1.24/go.mod h1:SLknhKksSoUtKzG2tvJKkN/DsMnGV+O+etmuj5Qew48=
 github.com/layer5io/meshkit v0.2.24/go.mod h1:blHAWgbcsNJ3rjKr8YvYke8jQILV75vRaARXYwSh0YA=
 github.com/layer5io/meshkit v0.2.28 h1:ZAMMRVuK2f2v+URlfgiy+uMPp99O7ygK/lrdK8GN3cc=
 github.com/layer5io/meshkit v0.2.28/go.mod h1:blHAWgbcsNJ3rjKr8YvYke8jQILV75vRaARXYwSh0YA=


### PR DESCRIPTION
Signed-off-by: leecalcote <leecalcote@gmail.com>

