### PR TITLE
[meshery-linkerd] Added kubeopenapi-jsonschema to meshery-linkerd image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,15 @@ COPY linkerd/ linkerd/
 
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-linkerd main.go
 
-FROM gcr.io/distroless/static
+FROM alpine:3.15 as jsonschema-util
+RUN apk add --no-cache curl
+WORKDIR /
+RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.0/kubeopenapi-jsonschema
+RUN chmod +x /kubeopenapi-jsonschema
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/nodejs:16
 ENV DISTRO="debian"
 ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-linkerd"
@@ -19,4 +27,5 @@ ENV MESHERY_SERVER="http://meshery:9081"
 WORKDIR /
 COPY templates/ ./templates
 COPY --from=build-env /github.com/layer5io/meshery-linkerd/meshery-linkerd .
+COPY --from=jsonschema-util /kubeopenapi-jsonschema /root/.meshery/bin/kubeopenapi-jsonschema
 ENTRYPOINT ["./meshery-linkerd"]


### PR DESCRIPTION
This PR adds the `kubeopenapi-jsonschema` binary to the `meshery-linkerd` image.

This PR also fixes #260 by updating the image from `gcr.io/distroless/static` to `gcr.io/distroless/nodejs:16`.

Signed-off-by: Jared Byers <j.byers@f5.com>

**Notes for Reviewers**
Referenced [the `meshery-istio` Dockerfile](https://github.com/meshery/meshery-istio/blob/master/Dockerfile#L19) for the change.

- [X] Yes, I signed my commits.


<!--
Thank you for contributing to Meshery! 
Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->