### PR TITLE
[CI] Update e2etests workflow to run on push

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -1,6 +1,13 @@
 name: (E2E Tests) Meshery Adapter for Linkerd Tests
 
 on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+    paths-ignore:
+      - 'docs/**'   
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
Signed-off-by: Anant Vijay <anantvijay3@gmail.com>

**Description**
The e2etests workflow would not on pushes, so that has to be updated to run on push.

This PR fixes #416 

**Notes for Reviewers**
Update e2etests.yaml


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!--
Thank you for contributing to Meshery! 
Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->