### PR TITLE
Update e2etests.yaml

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -24,10 +24,9 @@ jobs:
         uses: actions/checkout@master
       - name: Get latest release tag
         id: gettag
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: linkerd/linkerd2
-          excludes: prerelease, draft, edge 
+        run: |
+           NEW_LINKERD_VERSION=$(curl --silent "https://api.github.com/repos/linkerd/linkerd2/releases" | jq ' .[] | select(.tag_name|test("stable")) | ."tag_name"' | sed -n 1p$'\n' | tr -d '"')
+           echo "::set-output name=release::$NEW_LINKERD_VERSION"
       - name: Get stable release version
         id: getstabletag
         run: |


### PR DESCRIPTION
**Description**

Switch from the GitHub action to curl statement to fetch latest stable release of Linkerd service mesh.
Reason: that action doesn't support excluding edge releases so it always fetch latest edge release instead of latest stable release.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.


<!--
Thank you for contributing to Meshery! 
Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->